### PR TITLE
Fixed an outdated usage of "ship_to_different_address" post data.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://www.buymeacoffee.com/sofyansitorus?utm_source=wooreer_plugi
 Requires at least: 4.8
 Tested up to: 5.7
 Requires PHP: 5.6
-Stable tag: 2.1.13
+Stable tag: 2.1.14
 License: GPL-2.0+
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 
@@ -126,6 +126,11 @@ I always welcome and encourage contributions to this plugin. Please visit the pl
 > Upgrading from version 1.x to version 2.x is a major update and has breaking changes. Some **settings data will be lost** and **re-setup the plugin** after the upgrade is required.
 >
 > **Please upgrade wisely and carefully.**
+
+
+= 2.1.14 =
+
+* Fix - Fixd outdated usage of "ship_to_different_address" POST data.
 
 = 2.1.13 =
 

--- a/includes/classes/class-wcsdm-shipping-method.php
+++ b/includes/classes/class-wcsdm-shipping-method.php
@@ -2631,9 +2631,17 @@ class Wcsdm_Shipping_Method extends WC_Shipping_Method {
 			$destination_info[ $key ] = false;
 		}
 
+		$post_data = [];
+		
+		if ( ! empty( $_POST['post_data'] ) ) {
+			parse_str( $_POST['post_data'], $post_data );
+		} else {
+			$post_data = $_POST; // Support Old Versions
+		}
+
 		if ( wcsdm_is_calc_shipping() ) {
 			$shipping_fields = wcsdm_calc_shipping_fields();
-		} elseif ( ! empty( $_POST['ship_to_different_address'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		} elseif ( ! empty( $post_data['ship_to_different_address'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
 			$shipping_fields = wcsdm_shipping_fields();
 		} else {
 			$shipping_fields = wcsdm_billing_fields();

--- a/wcsdm.php
+++ b/wcsdm.php
@@ -15,7 +15,7 @@
  * Plugin Name:       WooReer
  * Plugin URI:        https://wooreer.com
  * Description:       WooCommerce shipping rates calculator allows you to easily offer shipping rates based on the distance calculated using Google Maps Distance Matrix Service API.
- * Version:           2.1.13
+ * Version:           2.1.14
  * Author:            Sofyan Sitorus
  * Author URI:        https://github.com/sofyansitorus
  * License:           GPL-2.0+


### PR DESCRIPTION
WooCommerce moved checkout post data to under 1-field named "post_data".

I fixed an outdated usage of "ship_to_different_address" post data
