### PR TITLE
V3 1 2

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -5,7 +5,7 @@ Donate link: https://www.buymeacoffee.com/sofyansitorus?utm_source=wooreer_plugi
 Requires at least: 6.4
 Tested up to: 6.9
 Requires PHP: 7.4
-Stable tag: 3.1.1
+Stable tag: 3.1.2
 License: GPL-2.0+
 License URI: http://www.gnu.org/licenses/gpl-2.0.txt
 
@@ -105,6 +105,10 @@ I always welcome and encourage contributions to this plugin. Please visit the pl
 7. Add New Rate Item
 
 == Changelog ==
+
+= 3.1.2 =
+
+* Enhancement - Enhance address field validation in distance calculation to handle incomplete addresses gracefully, with improved error logging.
 
 = 3.1.1 =
 

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 			"email": "sofyansitorus@gmail.com"
 		}
 	],
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"require-dev": {
 		"squizlabs/php_codesniffer": "^3.5",
 		"phpcompatibility/php-compatibility": "^9.3",

--- a/includes/api-providers/class-wcsdm-api-provider-distancematrix.php
+++ b/includes/api-providers/class-wcsdm-api-provider-distancematrix.php
@@ -498,7 +498,7 @@ class Wcsdm_API_Provider_Distancematrix extends Wcsdm_API_Provider_Base {
 	 * @uses   Wcsdm_Location::get_address_array() To get the structured address.
 	 * @uses   Wcsdm_Location::get_coordinates_latitude() To get the latitude.
 	 * @uses   Wcsdm_Location::get_coordinates_longitude() To get the longitude.
-	 * @uses   WC()->countries->get_formatted_address() For locale-aware address array formatting.
+	 * @uses   wcsdm_format_address_array() For locale-aware address array formatting.
 	 */
 	private function format_location( Wcsdm_Location $location ):string {
 		// Format location based on type: address, address_array, or coordinates.
@@ -510,7 +510,7 @@ class Wcsdm_API_Provider_Distancematrix extends Wcsdm_API_Provider_Base {
 			// Structured address array format - converts WooCommerce address components
 			// into a formatted string using country-specific formatting rules.
 			case 'address_array':
-				return WC()->countries->get_formatted_address( $location->get_address_array(), ', ' );
+				return wcsdm_format_address_array( $location->get_address_array() );
 
 			// Geographic coordinates format (default) - most precise location format.
 			// Used when latitude/longitude are available. Output format: "lat,lng".

--- a/includes/api-providers/class-wcsdm-api-provider-geoapify.php
+++ b/includes/api-providers/class-wcsdm-api-provider-geoapify.php
@@ -315,7 +315,7 @@ class Wcsdm_API_Provider_Geoapify extends Wcsdm_API_Provider_Base implements Wcs
 		if ( $location->get_location_type() === 'address_array' ) {
 			// Format the address array into a comma-separated string suitable for geocoding.
 			// WooCommerce's formatter handles proper ordering and formatting based on country.
-			$address_to_geocode = WC()->countries->get_formatted_address( $location->get_address_array(), ', ' );
+			$address_to_geocode = wcsdm_format_address_array( $location->get_address_array() );
 		}
 
 		// Check if location is provided as a plain address string (e.g., from settings).

--- a/includes/api-providers/class-wcsdm-api-provider-google.php
+++ b/includes/api-providers/class-wcsdm-api-provider-google.php
@@ -357,7 +357,7 @@ class Wcsdm_API_Provider_Google extends Wcsdm_API_Provider_Base {
 			// Format address array using WooCommerce address formatting.
 			case 'address_array':
 				return array(
-					'address' => WC()->countries->get_formatted_address( $location->get_address_array(), ', ' ),
+					'address' => wcsdm_format_address_array( $location->get_address_array() ),
 				);
 
 			// Format as latitude/longitude coordinates (default).

--- a/includes/api-providers/class-wcsdm-api-provider-mapbox.php
+++ b/includes/api-providers/class-wcsdm-api-provider-mapbox.php
@@ -368,7 +368,7 @@ class Wcsdm_API_Provider_Mapbox extends Wcsdm_API_Provider_Base {
 		if ( $location->get_location_type() === 'address_array' ) {
 			// Format the address array into a comma-separated string suitable for geocoding.
 			// WooCommerce's formatter handles proper ordering and formatting based on country.
-			$address_to_geocode = WC()->countries->get_formatted_address( $location->get_address_array(), ', ' );
+			$address_to_geocode = wcsdm_format_address_array( $location->get_address_array() );
 		}
 
 		// Check if location is provided as a plain address string (e.g., from settings).

--- a/includes/classes/class-wcsdm-shipping-method.php
+++ b/includes/classes/class-wcsdm-shipping-method.php
@@ -1537,7 +1537,7 @@ class Wcsdm_Shipping_Method extends WC_Shipping_Method {
 			return null;
 		}
 
-		$calculate_distance_destination = Wcsdm_Location::from_address_array( $destination_filtered );
+		$calculate_distance_destination = Wcsdm_Location::from_address_array( $destination );
 
 		return apply_filters(
 			'wcsdm_calculate_distance_destination',

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'WCSDM_VERSION', '3.1.1' );
+define( 'WCSDM_VERSION', '3.1.2' );
 define( 'WCSDM_DATA_VERSION', '3.0.0' );
 define( 'WCSDM_METHOD_ID', 'wcsdm' );
 define( 'WCSDM_METHOD_TITLE', 'WooReer' );

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -1128,3 +1128,23 @@ if ( ! function_exists( 'wcsdm_array_map_deep' ) ) :
 		return $value;
 	}
 endif;
+
+if ( ! function_exists( 'wcsdm_format_address_array' ) ) :
+	/**
+	 * Formats an address array into a human-readable string using WooCommerce's address formatting.
+	 *
+	 * This function leverages WooCommerce's built-in address formatting capabilities to convert
+	 * an associative array of address components into a properly formatted address string.
+	 * It uses the default formatting rules defined by WooCommerce, ensuring consistency with
+	 * other parts of the WooCommerce ecosystem.
+	 *
+	 * @since 3.1
+	 *
+	 * @param array $address_array An associative array containing address components.
+	 *                             Example keys: 'address_1', 'address_2', 'city', 'state', 'postcode', 'country'.
+	 * @return string The formatted address string.
+	 */
+	function wcsdm_format_address_array( array $address_array ):string {
+		return WC()->countries->get_formatted_address( $address_array, ', ' );
+	}
+endif;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wcsdm",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"description": "Calculate WooCommerce shipping rates based on distance via Google Maps Distance Matrix Service API",
 	"author": "",
 	"license": "GPL-2.0-or-later",

--- a/wcsdm.php
+++ b/wcsdm.php
@@ -15,7 +15,7 @@
  * Plugin Name:       WooReer
  * Plugin URI:        https://wooreer.com
  * Description:       WooCommerce shipping rates calculator allows you to offer shipping rates based on distance using Google Maps, Mapbox, or DistanceMatrix.ai.
- * Version:           3.1.1
+ * Version:           3.1.2
  * Author:            Sofyan Sitorus
  * Author URI:        https://github.com/sofyansitorus
  * License:           GPL-2.0+
@@ -24,7 +24,7 @@
  * Domain Path:       /languages
  *
  * WC requires at least: 8.8.0
- * WC tested up to: 10.4.3
+ * WC tested up to: 10.5.0
  */
 
 // If this file is called directly, abort.


### PR DESCRIPTION
This pull request updates the plugin to version 3.1.2 and focuses on enhancing address field validation during distance calculation. The main improvement is more robust handling of incomplete addresses, ensuring errors are logged more clearly and gracefully. Additionally, a new helper function is introduced to standardize address formatting, and all usages are updated to use this helper for consistency.

**Enhancements to Address Validation and Error Handling:**

* Improved validation logic in `class-wcsdm-shipping-method.php` to better handle incomplete addresses: now checks for minimum required fields, adjusts requirements for cart/shipping calculator contexts, and logs missing required fields with more detailed error messages. [[1]](diffhunk://#diff-23418dae7a73c3969c0c2f9bbc968b0841dedf7b267f3b92d5ec1bca1a63d170L1498-R1547) [[2]](diffhunk://#diff-23418dae7a73c3969c0c2f9bbc968b0841dedf7b267f3b92d5ec1bca1a63d170L1540-R1556)
* Changelog and documentation updated to reflect these validation enhancements.

**Address Formatting Refactor:**

* Introduced new helper function `wcsdm_format_address_array()` in `helpers.php` to standardize address formatting using WooCommerce's built-in logic.
* Replaced direct calls to `WC()->countries->get_formatted_address()` with the new helper in all API provider classes for consistent formatting. [[1]](diffhunk://#diff-91b5e81d434253bb63fd29b1c14418dcd5eba0f69a9aea2eedf1307ed6dd97bfL501-R501) [[2]](diffhunk://#diff-91b5e81d434253bb63fd29b1c14418dcd5eba0f69a9aea2eedf1307ed6dd97bfL513-R513) [[3]](diffhunk://#diff-5f8153a66a73090b18dc827f47f731e5f702cdfd0d24dfccd1eb34319546b6b3L318-R318) [[4]](diffhunk://#diff-94753ed6f5fea886500ec08490d901b33e6287fc4e4fb76a01b3a10ef4432ca4L360-R360) [[5]](diffhunk://#diff-fafe915018b755b8aaa5a99d72d0edd4b7684e6d3b45850a79e52c5951779529L371-R371)

**Version and Metadata Updates:**

* Bumped plugin version to 3.1.2 in all relevant files: `wcsdm.php`, `composer.json`, `package.json`, `constants.php`, and `README.txt`. [[1]](diffhunk://#diff-6318d598d3b85ebe22382149d18d19536ef80ff28eacda29f56783483048d0dbL18-R18) [[2]](diffhunk://#diff-6318d598d3b85ebe22382149d18d19536ef80ff28eacda29f56783483048d0dbL27-R27) [[3]](diffhunk://#diff-5b2745cb736851feee85bd78d0b7ce2f888a65e44f102b710a44f54946a4c035L18-R18) [[4]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L11-R11) [[5]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[6]](diffhunk://#diff-b01eeed0ec6fc4f4799e44c7b4084e649d6eee4f1aca52ac935553ff82108398L8-R8)